### PR TITLE
Heat modelling changes for the built environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store
 
 # rspec failure tracking
 .rspec_status

--- a/lib/fever/activity.rb
+++ b/lib/fever/activity.rb
@@ -5,6 +5,8 @@ module Fever
     attr_reader :producer
     attr_reader :share
     attr_reader :demand
+    attr_reader :demand_curve
+    attr_reader :production_curve
 
     # Creates a new Activity wrapping the given producer, with an optional
     # share.
@@ -12,6 +14,8 @@ module Fever
       @producer = producer
       @share    = share
       @demand   = 0.0
+      @demand_curve = Fever.empty_curve
+      @production_curve = Fever.empty_curve
     end
 
     # Public: Calculates the activity in the chosen frame.
@@ -19,7 +23,12 @@ module Fever
     # Returns the amount of energy used.
     def request(frame, amount)
       @demand += amount
-      @producer.request(frame, amount)
+      @demand_curve[frame] += amount
+
+      used = @producer.request(frame, amount)
+      @production_curve[frame] += used
+
+      used
     end
 
     def inspect


### PR DESCRIPTION
Modelling of heat demand in the built environment has been updated. Summarized:

- Residences are set to four types: apartments, detached houses, semi-detached houses, terraced houses
- Residences are split into 6 construction periods: before 1945, 1945-1964, 1965-1984, 1985-2004, 2005 to present and future
- Buildings are split into 2 construction periods: present and future
- Useful space heating demand is no longer aggregated to a single node, but each residence of a certain type and construction period is connected to all heating technologies, the same goes for buildings
- Merit orders are added to determine allocation of technologies to residences
- Dataset initialisation (refinery and atlas) and required data (etdataset and etlocal) is updated
- Frontend charts, slides and sliders are updated
- Insulation has been changed, instead of setting a demand reduction, the typical useful demand of each residence and building can be adjusted
- Insulation costs queries are updated
- Useful demand can be assigned two different curves, depending on the technology one of the curves will be selected
- Deficits are calculated based on the capacity of the technology and the hourly demand of each residence and building

Goes with

- https://github.com/quintel/fever/pull/1
- https://github.com/quintel/refinery/pull/61
- https://github.com/quintel/atlas/pull/164
- https://github.com/quintel/etengine/pull/1386
- https://github.com/quintel/etsource/pull/2997
- https://github.com/quintel/etmodel/pull/4193
- https://github.com/quintel/etdataset/pull/989
- https://github.com/quintel/etlocal/pull/503