### PR TITLE
Prep gem for Ruby 4.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,5 +20,3 @@ blocks:
               values:
                 - '3.3'
                 - '4.0'
-      secrets:
-        - name: Fever

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,11 +14,15 @@ blocks:
             - sem-version ruby $RUBY_VERSION
             - gem install bundler -v ">= 2.0"
             - bundle install
-            - bundle exec rspec
+            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format progress
           matrix:
             - env_var: RUBY_VERSION
               values:
-                - 2.7.5
-                - 3.1.1
+                - '3.3'
+                - '4.0'
       secrets:
         - name: Fever
+      epilogue:
+        always:
+          commands:
+            - test-results publish junit.xml

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ blocks:
             - sem-version ruby $RUBY_VERSION
             - gem install bundler -v ">= 2.0"
             - bundle install
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format progress
+            - bundle exec rspec
           matrix:
             - env_var: RUBY_VERSION
               values:
@@ -22,7 +22,3 @@ blocks:
                 - '4.0'
       secrets:
         - name: Fever
-      epilogue:
-        always:
-          commands:
-            - test-results publish junit.xml

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 gemspec
 
 # Merit is here since it isn't currently published to RubyGems.org
-gem 'quintel_merit', ref: '56217e5', github: 'quintel/merit' #TODO: update to correct red once merged to master!
+gem 'quintel_merit', ref: 'e59980a', github: 'quintel/merit' #TODO: update once merged to master
 
 # Development- and test-related non-essentials.
 group(:extras) do

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 gemspec
 
 # Merit is here since it isn't currently published to RubyGems.org
-gem 'quintel_merit', ref: 'master', github: 'quintel/merit'
+gem 'quintel_merit', ref: '56217e5', github: 'quintel/merit' #TODO: update to correct red once merged to master!
 
 # Development- and test-related non-essentials.
 group(:extras) do

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 gemspec
 
 # Merit is here since it isn't currently published to RubyGems.org
-gem 'quintel_merit', ref: 'e59980a', github: 'quintel/merit' #TODO: update once merged to master
+gem 'quintel_merit', ref: 'aae77e0', github: 'quintel/merit'
 
 # Development- and test-related non-essentials.
 group(:extras) do

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -3,8 +3,3 @@ require 'simplecov'
 SimpleCov.start do
   add_filter('/spec')
 end
-
-if ENV['CI']
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end


### PR DESCRIPTION
#### Context

In an ongoing effort to prepare the internal gems for the upcoming Ruby4/Rails8 update, we updated their semaphore checks to use versions 3.3 and 4.0. Then run their RSpec tests locally against this 2 versions to identify any early issues (at gem level) and fix them.

#### Implemented changes

- refinery: Update Ruby version checks to 3.3/4.0
- fever: Update Ruby version checks to 3.3/4.0
- merit: Update Ruby version checks to 3.3/4.0 and add csv dependency
- atlas: Update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0 
- identity_rails: Add simplecov, update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0
- transformer: Add simplecov, unpin ruby-version then set Ruby version checks for 3.3/4.0 
- rubel: Add rspec and simplecov, fix some specs then set Ruby version checks for 3.3/4.0
- osmosis: Standarize simplecov, add bigdecimal dependency, fix some specs then set Ruby version checks for 3.3/4.0
- turbine: Standarize simplecov, add rspec-collection_matchers, fix specs then set Ruby version checks for 3.3/4.0

#### Related

Goes with pull requests:
- refinery: https://github.com/quintel/refinery/pull/63
- fever: https://github.com/quintel/fever/pull/2 [THIS ONE]
- merit: https://github.com/quintel/merit/pull/160
- atlas: https://github.com/quintel/atlas/pull/187
- identity_rails: https://github.com/quintel/identity_rails/pull/7
- transformer: https://github.com/quintel/transformer/pull/19
- rubel: https://github.com/quintel/rubel/pull/1
- osmosis: https://github.com/quintel/osmosis/pull/1
- turbine: https://github.com/quintel/turbine/pull/5

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review